### PR TITLE
Windows - Create the Khronos\OpenXR\1\ApiLayers\Implicit if it doesn't exist

### DIFF
--- a/src/windows/WindowsAPILayerStore.cpp
+++ b/src/windows/WindowsAPILayerStore.cpp
@@ -43,12 +43,12 @@ WindowsAPILayerStore::WindowsAPILayerStore(
       rootKey,
       SubKey,
       0,
-      NULL,
+      nullptr,
       REG_OPTION_NON_VOLATILE,
       samFlags,
-      NULL,
+      nullptr,
       mKey.put(),
-      NULL)
+      nullptr)
     != ERROR_SUCCESS) {
 #ifndef NDEBUG
     __debugbreak();

--- a/src/windows/WindowsAPILayerStore.cpp
+++ b/src/windows/WindowsAPILayerStore.cpp
@@ -39,7 +39,17 @@ WindowsAPILayerStore::WindowsAPILayerStore(
       break;
   }
   if (
-    RegOpenKeyExW(rootKey, SubKey, 0, samFlags, mKey.put()) != ERROR_SUCCESS) {
+    RegCreateKeyExW(
+      rootKey,
+      SubKey,
+      0,
+      NULL,
+      REG_OPTION_NON_VOLATILE,
+      samFlags,
+      NULL,
+      mKey.put(),
+      NULL)
+    != ERROR_SUCCESS) {
 #ifndef NDEBUG
     __debugbreak();
 #endif


### PR DESCRIPTION
Hello,

Thank you for your great tool, it helps me a lot when managing my layers!

Recently, I had to install a layer on a computer that never had one installed and this app could not create the registry key.

This little pull-request allows the app to create the registry key if it is not already there.

Maybe the original behavior of the app was the one intended (for security reasons?) and in this case fell free to discard this PR.

Don't hesitate to contact me if you want more informations, even though I think the changes are quite minimal