### PR TITLE
✨ Linter: put OXRMC below OpenKneeboard

### DIFF
--- a/src/LayerRules.cpp
+++ b/src/LayerRules.cpp
@@ -28,10 +28,13 @@ DEFINE_EXTENSION_ID(XR_VARJO_foveated_rendering)
 }// namespace ExtensionIDs
 
 namespace Facets {
-constexpr Facet CompositionLayers {
-  "#compositionLayers",
-  "provides an overlay",
-};
+#define DEFINE_FACET(name, description) \
+  static constexpr Facet name {"#" #name, description};
+DEFINE_FACET(CompositionLayers, "provides an overlay")
+DEFINE_FACET(TransformsPoses, "modifies poses")
+DEFINE_FACET(UsesGameWorldPoses, "uses poses")
+#undef DEFINE_FACET
+
 }// namespace Facets
 
 namespace {
@@ -54,6 +57,12 @@ struct Literals {
 std::vector<LayerRules> GetLayerRules() {
   return {
     {
+      .mID = Facets::TransformsPoses,
+      .mBelow = Literals {
+        Facets::UsesGameWorldPoses,
+      },
+    },
+    {
       .mID = XR_APILAYER_FREDEMMOTT_HandTrackedCockpitClicking,
       .mAbove = Literals {
         XR_EXT_hand_tracking,
@@ -63,6 +72,7 @@ std::vector<LayerRules> GetLayerRules() {
       .mID = XR_APILAYER_FREDEMMOTT_OpenKneeboard,
       .mFacets = Literals {
         Facets::CompositionLayers,
+        Facets::UsesGameWorldPoses,
       },
     },
     {
@@ -93,6 +103,9 @@ std::vector<LayerRules> GetLayerRules() {
         // Unknown incompatibility issue:
         XR_APILAYER_FREDEMMOTT_HandTrackedCockpitClicking,
       },
+      .mFacets = Literals {
+        Facets::TransformsPoses,
+      },
     },
     {
       .mID = XR_APILAYER_MBUCCHIA_vulkan_d3d12_interop,
@@ -119,7 +132,7 @@ std::vector<LayerRules> GetLayerRules() {
         // - Other developers have mentioned thread safety issues in XRNS that can cause crashes; I've not confirmed these
         XR_APILAYER_FREDEMMOTT_OpenKneeboard,
       },
-    },
+    }
   };
 }
 


### PR DESCRIPTION
This is done by:
- adding `TransformsPoses` and `UsesGameWorldPoses` facets
- adding a relationship between the facets (support added in d587aab8105ae0ade2febe89b504b847952b8893)
- tagging OXRMC and OpenKneeboard with the relevant facets

I've not tagged XRNS with `TransformsPoses` due to known bugs in the layer (which are reported); XRNS needs to stick with explicit rules until they are fixed.

fixes #17